### PR TITLE
Added independence to top_nav

### DIFF
--- a/app/src/main/js/actions/nav.js
+++ b/app/src/main/js/actions/nav.js
@@ -1,0 +1,10 @@
+import NAV from '../consts/nav';
+
+export const tabbedNav = (items) => ({
+    type: NAV.TABBED,
+    items
+})
+
+export const blankNav = () => ({
+    type: NAV.BLANK
+})

--- a/app/src/main/js/actions/nav.js
+++ b/app/src/main/js/actions/nav.js
@@ -1,10 +1,15 @@
 import NAV from '../consts/nav';
 
 export const tabbedNav = (items) => ({
-    type: NAV.TABBED,
+    type: NAV.TYPE.TABBED,
     items
-})
+});
 
 export const blankNav = () => ({
-    type: NAV.BLANK
+    type: NAV.TYPE.BLANK
+});
+
+export const tabItem = (i) => ({
+    type: NAV.ITEM,
+    item: i
 })

--- a/app/src/main/js/components/nav.js
+++ b/app/src/main/js/components/nav.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import SideNav from '../containers/navigation/side_nav';
+import TopNav from '../containers/navigation/top_nav';
 
 function Nav() {
   return (
     <div>
-      <div className="top_nav">
-        <div className="top_nav_container" />
-      </div>
+      <TopNav />
       <SideNav />
     </div>
   );

--- a/app/src/main/js/components/settings.js
+++ b/app/src/main/js/components/settings.js
@@ -1,7 +1,10 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import ToggleableSettings from '../containers/settings/toggleable_settings';
+import { blankNav } from '../actions/nav';
 
-function Settings() {
+function Settings(props) {
+  props.blankNav();
   return (
     <div className="main_container">
       <ToggleableSettings />
@@ -9,4 +12,8 @@ function Settings() {
   );
 }
 
-export default Settings;
+const mapDispatchToProps = {
+  blankNav
+}
+
+export default connect(null, mapDispatchToProps)(Settings);

--- a/app/src/main/js/consts/nav.js
+++ b/app/src/main/js/consts/nav.js
@@ -1,0 +1,4 @@
+export default {
+    TABBED: "TABBED_NAV",
+    BLANK: "BLANK_NAV"
+}

--- a/app/src/main/js/consts/nav.js
+++ b/app/src/main/js/consts/nav.js
@@ -1,4 +1,8 @@
 export default {
-    TABBED: "TABBED_NAV",
-    BLANK: "BLANK_NAV"
+    TYPE: {
+        TABBED: "TABBED_NAV",
+        BLANK: "BLANK_NAV",
+        NONE: "NONE_NAV",
+    },
+    ITEM: "NAV_ITEM",
 }

--- a/app/src/main/js/containers/feeds/rants.js
+++ b/app/src/main/js/containers/feeds/rants.js
@@ -6,6 +6,7 @@ import { fetch, resetPage } from '../../actions/rants';
 import STATE from '../../consts/state';
 import FEED from '../../consts/feed';
 import TopNav from '../navigation/top_nav';
+import { tabbedNav } from '../../actions/nav';
 
 // Use import instead?
 const twemoji = require('twemoji');
@@ -65,6 +66,7 @@ class Rants extends Component {
 
   render() {
     const { rants } = this.props;
+    this.props.updateTopNav(Object.values(FEED.RANTS));
 
     if (rants.state === STATE.LOADING && rants.currentRants.length === 0) {
       return (
@@ -120,4 +122,10 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, { fetch, resetPage })(Rants);
+const mapDispatchToProps = (dispatch) => ({
+  fetch: (m, e, o, w) => fetch(m, e, o, w)(dispatch),
+  resetPage: () => resetPage()(dispatch),
+  updateTopNav: (r) => dispatch(tabbedNav(r))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Rants);

--- a/app/src/main/js/containers/feeds/rants.js
+++ b/app/src/main/js/containers/feeds/rants.js
@@ -6,7 +6,7 @@ import { fetch, resetPage } from '../../actions/rants';
 import STATE from '../../consts/state';
 import FEED from '../../consts/feed';
 import TopNav from '../navigation/top_nav';
-import { tabbedNav } from '../../actions/nav';
+import { tabbedNav, tabItem } from '../../actions/nav';
 
 // Use import instead?
 const twemoji = require('twemoji');
@@ -19,11 +19,13 @@ class Rants extends Component {
   }
 
   componentWillMount() {
+    const DEFAULT_TAB_ITEM = FEED.RANTS.ALGO
     this.props.fetch(
-      'Algo',
+      DEFAULT_TAB_ITEM,
       25,
       25 * this.props.rants.page,
     );
+    this.props.updateTabItem(DEFAULT_TAB_ITEM);
   }
 
   componentDidMount() {
@@ -125,7 +127,8 @@ function mapStateToProps(state) {
 const mapDispatchToProps = (dispatch) => ({
   fetch: (m, e, o, w) => fetch(m, e, o, w)(dispatch),
   resetPage: () => resetPage()(dispatch),
-  updateTopNav: (r) => dispatch(tabbedNav(r))
+  updateTopNav: (r) => dispatch(tabbedNav(r)),
+  updateTabItem: (r) => dispatch(tabItem(r)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Rants);

--- a/app/src/main/js/containers/feeds/rants.js
+++ b/app/src/main/js/containers/feeds/rants.js
@@ -16,16 +16,24 @@ class Rants extends Component {
   constructor(props) {
     super(props);
     this.handleScroll = this.handleScroll.bind(this);
+    // this.state = {
+    //   firstTime: true
+    // }
+    // const DEFAULT_TAB_ITEM = FEED.RANTS.ALGO
+    // props.updateTabItem(DEFAULT_TAB_ITEM);
+    // this.fetchRants(DEFAULT_TAB_ITEM);
   }
 
   componentWillMount() {
     const DEFAULT_TAB_ITEM = FEED.RANTS.ALGO
-    this.props.fetch(
-      DEFAULT_TAB_ITEM,
-      25,
-      25 * this.props.rants.page,
-    );
+    // this.props.fetch(
+    //   DEFAULT_TAB_ITEM,
+    //   25,
+    //   25 * this.props.rants.page,
+    // );
+    this.fetchRants(DEFAULT_TAB_ITEM);
     this.props.updateTabItem(DEFAULT_TAB_ITEM);
+    this.props.updateTopNav(Object.values(FEED.RANTS));
   }
 
   componentDidMount() {
@@ -47,17 +55,18 @@ class Rants extends Component {
     const scrollTop = document.getElementsByClassName('main_container')[0].scrollTop;
 
     if (scrollTop + (windowHeight * 2) >= scrollHeight && rants.state !== STATE.LOADING) {
-      this.props.fetch(
-        rants.feedType,
-        25,
-        25 * rants.page,
-        this.props.authToken,
-      );
+      // this.props.fetch(
+      //   rants.feedType,
+      //   25,
+      //   25 * rants.page,
+      //   this.props.authToken,
+      // );
+      this.fetchRants(rants.feedType);
     }
   }
 
   fetchRants(type) {
-    this.props.resetPage();
+    // this.props.resetPage();
     this.props.fetch(
       type,
       25,
@@ -67,8 +76,14 @@ class Rants extends Component {
   }
 
   render() {
+    // if (this.state.firstTime) {
+    //   this.setState({ firstTime: false });
+    // } else {
+    //   this.fetchRants(this.props.selectedItem);
+    // }
+
     const { rants } = this.props;
-    this.props.updateTopNav(Object.values(FEED.RANTS));
+    // this.props.updateTopNav(Object.values(FEED.RANTS));
 
     if (rants.state === STATE.LOADING && rants.currentRants.length === 0) {
       return (
@@ -121,6 +136,7 @@ function mapStateToProps(state) {
   return {
     rants: state.rants,
     authToken: state.auth.authToken,
+    selectedItem: state.topNav.selectedItem,
   };
 }
 

--- a/app/src/main/js/containers/feeds/rants.js
+++ b/app/src/main/js/containers/feeds/rants.js
@@ -88,10 +88,6 @@ class Rants extends Component {
     if (rants.state === STATE.LOADING && rants.currentRants.length === 0) {
       return (
         <div style={{ display: 'flex' }}>
-          <TopNav
-            items={Object.values(FEED.RANTS)}
-            fetch={type => this.fetchRants(type)}
-          />
           <div id="loaderCont" >
             <div className="loader" id="loader1" />
             <div className="loader" id="loader2" />
@@ -102,10 +98,6 @@ class Rants extends Component {
 
     return (
       <div>
-        <TopNav
-          items={Object.values(FEED.RANTS)}
-          fetch={type => this.fetchRants(type)}
-        />
         <RantItem />
         <div className="row rantContainer" >
           {

--- a/app/src/main/js/containers/navigation/top_nav.js
+++ b/app/src/main/js/containers/navigation/top_nav.js
@@ -71,6 +71,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   updateItem: (i) => dispatch(tabItem(i)),
   resetPage: () => resetPage()(dispatch),
+  fetch: (m, e, o, w) => fetch(m, e, o, w)(dispatch),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TopNav);

--- a/app/src/main/js/containers/navigation/top_nav.js
+++ b/app/src/main/js/containers/navigation/top_nav.js
@@ -3,12 +3,12 @@ import { connect } from 'react-redux';
 import { tabItem } from '../../actions/nav';
 
 class TopNav extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      activeItem: '',
-    };
-  }
+  // constructor(props) {
+  //   super(props);
+    // this.state = {
+    //   activeItem: '',
+    // };
+  // }
 
   onClickTabItem(type) {
     this.props.updateItem(type);
@@ -23,7 +23,7 @@ class TopNav extends Component {
           {
           this.props.items.map((item) => {
             let activeStyle = '';
-            if (this.state.activeItem === item) {
+            if (this.props.selectedItem === item) {
               activeStyle = '1px solid white';
             }
             return (
@@ -54,7 +54,8 @@ TopNav.defaultProps = {
 };
 
 const mapStateToProps = (state) => ({
-  items: state.topNav.items
+  items: state.topNav.items,
+  selectedItem: state.topNav.selectedItem,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/src/main/js/containers/navigation/top_nav.js
+++ b/app/src/main/js/containers/navigation/top_nav.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { tabItem } from '../../actions/nav';
+import { resetPage, fetch } from '../../actions/rants';
 
 class TopNav extends Component {
   // constructor(props) {
@@ -12,8 +13,15 @@ class TopNav extends Component {
 
   onClickTabItem(type) {
     this.props.updateItem(type);
-    this.props.fetch(type);
-    this.setState({ activeItem: type });
+    this.props.resetPage();
+    this.props.fetch(
+      type,
+      25,
+      25 * this.props.rants.page,
+      this.props.authToken,
+    );
+    // this.props.fetch(type);
+    // this.setState({ activeItem: type });
   }
 
   render() {
@@ -56,10 +64,13 @@ TopNav.defaultProps = {
 const mapStateToProps = (state) => ({
   items: state.topNav.items,
   selectedItem: state.topNav.selectedItem,
+  authToken: state.auth.authToken,
+  rants: state.rants,
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  updateItem: (i) => dispatch(tabItem(i))
+  updateItem: (i) => dispatch(tabItem(i)),
+  resetPage: () => resetPage()(dispatch),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TopNav);

--- a/app/src/main/js/containers/navigation/top_nav.js
+++ b/app/src/main/js/containers/navigation/top_nav.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { tabItem } from '../../actions/nav';
 
 class TopNav extends Component {
   constructor(props) {
@@ -8,7 +10,8 @@ class TopNav extends Component {
     };
   }
 
-  changeTopNav(type) {
+  onClickTabItem(type) {
+    this.props.updateItem(type);
     this.props.fetch(type);
     this.setState({ activeItem: type });
   }
@@ -26,7 +29,7 @@ class TopNav extends Component {
             return (
               <button
                 className="btn"
-                onClick={() => this.changeTopNav(item)}
+                onClick={() => this.onClickTabItem(item)}
                 key={item}
                 style={{ borderBottom: activeStyle }}
               >
@@ -50,4 +53,12 @@ TopNav.defaultProps = {
   items: [],
 };
 
-export default TopNav;
+const mapStateToProps = (state) => ({
+  items: state.topNav.items
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  updateItem: (i) => dispatch(tabItem(i))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TopNav);

--- a/app/src/main/js/reducers/index.js
+++ b/app/src/main/js/reducers/index.js
@@ -3,14 +3,14 @@ import theme from './settings';
 import rants from './rants';
 import rant from './rant';
 import auth from './auth';
-import { TopNavItems } from './nav';
+import { TopNav } from './nav';
 
 const rootReducer = combineReducers({
   theme,
   rants,
   rant,
   auth,
-  topNavItems: TopNavItems,
+  topNav: TopNav,
 });
 
 export default rootReducer;

--- a/app/src/main/js/reducers/index.js
+++ b/app/src/main/js/reducers/index.js
@@ -3,12 +3,14 @@ import theme from './settings';
 import rants from './rants';
 import rant from './rant';
 import auth from './auth';
+import { TopNavItems } from './nav';
 
 const rootReducer = combineReducers({
   theme,
   rants,
   rant,
   auth,
+  topNavItems: TopNavItems,
 });
 
 export default rootReducer;

--- a/app/src/main/js/reducers/nav.js
+++ b/app/src/main/js/reducers/nav.js
@@ -1,0 +1,15 @@
+import NAV from '../consts/nav';
+
+export function TopNavItems(state = [], action) {
+    switch (action.type) {
+        case NAV.TABBED: {
+            return action.items;
+        }
+        case NAV.BLANK: {
+            return [];
+        }
+        default: {
+            return state;
+        }
+    }
+}

--- a/app/src/main/js/reducers/nav.js
+++ b/app/src/main/js/reducers/nav.js
@@ -1,15 +1,46 @@
 import NAV from '../consts/nav';
 
-export function TopNavItems(state = [], action) {
+function TopNavItems(state = [], action) {
     switch (action.type) {
-        case NAV.TABBED: {
+        case NAV.TYPE.TABBED: 
             return action.items;
-        }
-        case NAV.BLANK: {
+        
+        case NAV.TYPE.BLANK: 
             return [];
-        }
+        
+        case NAV.TYPE.NONE:
+            return null;
+
         default: {
             return state;
         }
+    }
+}
+
+function CurrentItem(state = '', action) {
+    switch (action.type) {
+        case NAV.ITEM:
+            return action.item;
+        default:
+            return state;
+    }
+}
+
+export function TopNav (state = {}, action) {
+    switch (action.type) {
+        case NAV.TYPE.BLANK:
+        case NAV.TYPE.NONE:
+        case NAV.TYPE.TABBED:
+            return {
+                selectedItem: state.selectedItem,
+                items: TopNavItems(state.items, action)
+            }
+        case NAV.ITEM:
+            return {
+                selectedItem: CurrentItem(state.selectedItem, action),
+                items: state.items
+            }
+        default:
+            return state
     }
 }


### PR DESCRIPTION
# Current view of the state/store:
![state](http://image.prntscr.com/image/15e9560c3a5f461a964e0019f37e9f6a.png)

* added topNav which stores selectedItem as well as the items that should be present in the top_nav
* no overlapping of top_nav div containers
* blanks out in settings page (as intended)