### PR TITLE
Added Frameless Window support for macOS

### DIFF
--- a/app/src/main/app.js
+++ b/app/src/main/app.js
@@ -122,6 +122,7 @@ function createWindow() {
     minHeight: 768,
     minWidth: 1024,
     show: false,
+    titleBarStyle: 'hidden',
   });
 
   if (process.env.NODE_ENV === 'development') {

--- a/app/src/main/js/routes/main.js
+++ b/app/src/main/js/routes/main.js
@@ -17,6 +17,7 @@ import Search from '../containers/search/search';
 
 const MainRoutes = props => (
   <div key="MainRoutes" className="main_container" >
+    <div className="draggable-region" />
     <SideNav />
     <div
       className="middle_container"

--- a/app/src/main/res/css/modules/common.sass
+++ b/app/src/main/res/css/modules/common.sass
@@ -14,6 +14,15 @@ $post_comment_height: 13rem
   background: transparent
   border-radius: 20px
 
+.draggable-region
+  position: fixed
+  top: 0
+  width: 100%
+  height: 25px
+  background-color: transparent
+  -webkit-app-region: drag
+  z-index: 10
+
 .emoji
   height: 18px !important
   width: 18px !important


### PR DESCRIPTION
I love [Electron's frameless apps on macOS](https://electron.atom.io/docs/api/frameless-window/) and I believe many people also do. So I added some lines of code to make the app looks better.
Hope you will love it.

![image](https://user-images.githubusercontent.com/9253690/29485431-fb9b7cc8-84fb-11e7-82e3-0eab66cc1f70.png)
