### PR TITLE
Added snap support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,16 @@
     "linux": {
       "target": [
         "deb",
-        "AppImage"
+        "AppImage",
+        "snap"
+      ]
+    },
+    "snap": {
+      "plugs": [
+        "default"
+      ],
+      "after": [
+        "desktop-gtk2"
       ]
     },
     "mac": {
@@ -89,7 +98,7 @@
     "cross-env": "^5.1.3",
     "css-loader": "^0.28.7",
     "electron": "^1.7.10",
-    "electron-builder": "^19.49.2",
+    "electron-builder": "^19.53.0",
     "env-paths": "^1.0.0",
     "eslint": "^4.14.0",
     "eslint-config-airbnb": "^16.1.0",
@@ -117,7 +126,7 @@
     "dompurify": "^1.0.3",
     "electron-devtools-installer": "^2.2.3",
     "electron-settings": "^3.1.4",
-    "electron-updater": "^2.17.6",
+    "electron-updater": "^2.18.2",
     "fuse.js": "^3.2.0",
     "jquery": "^3.2.1",
     "json-schema-traverse": "^0.3.1",


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04, but it should work just as well on Ubuntu 17.10, Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and ```npm run dist``` it will create ```dist/devrantron_1.5.0_amd64.snap```.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run: 
```sudo snap install devrantron_1.5.0_amd64.snap --dangerous``` 

Run with ```devrantron``` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and [https://snapcraft.io/discover](https://snapcraft.io/discover/). To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "devrantron" name](https://dashboard.snapcraft.io/register-snap/?name=devrantron).

You'll need the snapcraft command to push the snap file to the store.

If you're on a Mac, you can ```brew install snapcraft```
If you're on Linux, it's ```sudo snap install --classic snapcraft```
Then you can push Ling out with:
```snapcraft push  dist/devrantron_1.5.0_amd64.snap --release stable```