### PR TITLE
Replaced the manual date formatting with "toLocaleDateString"

### DIFF
--- a/app/src/js/consts/utils.js
+++ b/app/src/js/consts/utils.js
@@ -99,8 +99,7 @@ export const timeSince = (date) => {
   const seconds = Math.floor((new Date() - date) / 1000);
   let interval = seconds / 2592000;
   if (interval > 1) {
-    const nd = new Date(date);
-    return `${nd.getDate()}/${nd.getMonth()}/${nd.getYear().toString().substring(1)}`;
+    return new Date(date).toLocaleDateString('en-GB', { year: '2-digit', month: 'numeric', day: 'numeric' });
   }
   interval = seconds / 86400;
   if (interval > 1) {


### PR DESCRIPTION
This fixes a slight oversight of the fact that months are 0-based in JS Date functions.
The date formatting previously was done manually without adding `1` to the month integer.
Also instead of manually constructing the date string, it is now rendered using [Date.prototype.toLocaleDateString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString).

Fixes #252 