### PR TITLE
Changed max comment character count from 2000 to 1000

### DIFF
--- a/app/src/js/components/comments/comment_post.js
+++ b/app/src/js/components/comments/comment_post.js
@@ -107,7 +107,7 @@ class CommentPost extends Component {
           onPost={(text, image) => this.onPost(text, image)}
           disabled={this.state.disabled || auth.user === null}
           value={this.state.content}
-          maxChar={2000}
+          maxChar={1000}
           onChange={text => this.setState({ content: text })}
           ref={(node) => { this.smartArea = node; }}
           editing={this.state.editID !== 0}


### PR DESCRIPTION
Over at devRant.com the max character count on a comment is 1000. In devRantron it's 2000.

I tried posting a comment with >1000 characters, and the comment disappeared. That's fixed in this PR.